### PR TITLE
feat: Update saveJobPostings to use user_email instead of user_id

### DIFF
--- a/src/app/(pages)/(dashboard)/_components/DashboardClient.tsx
+++ b/src/app/(pages)/(dashboard)/_components/DashboardClient.tsx
@@ -27,7 +27,12 @@ export default function DashboardClient({ user, accessToken }: DashboardClientPr
   }
 
   if (!emails || !Array.isArray(emails)) {
-    return <div>No emails found...</div>;
+    return (
+      <div>
+        No emails found...
+        <button onClick={() => signOut({ callbackUrl: "/" })}>Sign out</button>
+      </div>
+    );
   }
 
   return (

--- a/src/app/(pages)/(dashboard)/_services/emailServices.ts
+++ b/src/app/(pages)/(dashboard)/_services/emailServices.ts
@@ -9,9 +9,50 @@ export const fetchEmails = async (accessToken: string, userEmail: string) => {
     body: JSON.stringify({ email: userEmail }),
   });
 
+  console.log("response from fetchEmails", res);
+
   if (!res.ok) {
     throw new Error(`Request failed with status ${res.status}`);
   }
 
   return res.json();
+};
+
+// _services/emailServices.ts
+
+export const saveJobPostings = async (
+  jobPostings: unknown[],
+  userEmail: string | null | undefined
+) => {
+  try {
+    const API_BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL || "http://localhost:8000";
+
+    const res = await fetch(`${API_BASE_URL}/api/job-postings/save-job-postings`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        user_email: userEmail, // NOTE: using user email instead of user id as this is auto-generated for us via postgres
+        job_postings: jobPostings,
+      }),
+    });
+
+    console.log("response from saveJobPostings", res);
+
+    if (!res.ok) {
+      // Attempt to parse JSON error response
+      try {
+        const errorData = await res.json();
+        console.error("Error saving job postings:", errorData.error);
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      } catch (e) {
+        console.error("Error saving job postings: Unable to parse error response");
+      }
+    } else {
+      console.log("Job postings saved successfully!");
+    }
+  } catch (error) {
+    console.error("Error:", error);
+  }
 };


### PR DESCRIPTION
- Updated the `saveJobPostings` function to send `user_email` to the backend.
- Ensured consistent usage of `user_email` throughout `useFetchEmails` and related components.
- Improved error handling and logging for save operations.
- user_email allows us to now sync job_postings to our django be and thus our postgres db